### PR TITLE
Add an option to customize the htmlpurifier whitelists from the module settings

### DIFF
--- a/components/Container.php
+++ b/components/Container.php
@@ -122,8 +122,8 @@ class Container extends Behavior
     public function validatePhpType($attribute, $params)
     {
         if($this->isType(self::TYPE_PHP)) {
-            $settigns = new SettingsForm();
-            if($this->owner->isNewRecord && !$settigns->phpPagesActive) {
+            $settings = new SettingsForm();
+            if($this->owner->isNewRecord && !$settings->phpPagesActive) {
                 throw new HttpException(403);
             }
 

--- a/models/ContainerPage.php
+++ b/models/ContainerPage.php
@@ -69,64 +69,64 @@ class ContainerPage extends ContentActiveRecord implements Searchable, CustomCon
     {
         $rules = $this->defaultRules();
         $rules[] = ['in_new_window', 'integer'];
-	    $rules[] = [['title'], 'filter', 'filter' => array($this, 'reformatFilter')];
-	    $rules[] = [['page_content'], 'safe', 'when' => array($this, 'isNotHtml')];
-	    $rules[] = [['page_content'], 'filter', 'when' => array($this, 'isHtml'), 'filter' => array($this, 'purifyFilter')];
+        $rules[] = [['title'], 'filter', 'filter' => array($this, 'reformatFilter')];
+        $rules[] = [['page_content'], 'safe', 'when' => array($this, 'isNotHtml')];
+        $rules[] = [['page_content'], 'filter', 'when' => array($this, 'isHtml'), 'filter' => array($this, 'purifyFilter')];
 
         return $rules;
     }
 
-	/**
-	 * @param ContainerPage $model the HTML code container
-	 * @return bool whether it is an html type container
-	 */
-	public function isHtml($model)
-	{
-		return $model->type == Container::TYPE_HTML;
-	}
+    /**
+     * @param ContainerPage $model the HTML code container
+     * @return bool whether it is an html type container
+     */
+    public function isHtml($model)
+    {
+        return $model->type == Container::TYPE_HTML;
+    }
 
-	/**
-	 * @param ContainerPage $model the HTML code
-	 * @return bool whether it is not an html type container
-	 */
-	public function isNotHtml($model)
-	{
-		return $model->type != Container::TYPE_HTML;
-	}
+    /**
+     * @param ContainerPage $model the HTML code
+     * @return bool whether it is not an html type container
+     */
+    public function isNotHtml($model)
+    {
+        return $model->type != Container::TYPE_HTML;
+    }
 
-	/**
-	 * strip the title from html tags
-	 * if all is stripped, the title will be "Unnamed_" + a random string, might find a better naming
-	 *
-	 * @param string $title the Title to be stripped
-	 * @return string the stripped title
-	 * @throws \yii\base\Exception
-	 */
-	public function reformatFilter($title)
-	{
-		$strippedTitle = trim(strip_tags($title));
-		if ($strippedTitle == '') {
-			return 'Unnamed_'.Yii::$app->security->generateRandomString(6);
-		}
-		return $strippedTitle;
-	}
+    /**
+     * strip the title from html tags
+     * if all is stripped, the title will be "Unnamed_" + a random string, might find a better naming
+     *
+     * @param string $title the Title to be stripped
+     * @return string the stripped title
+     * @throws \yii\base\Exception
+     */
+    public function reformatFilter($title)
+    {
+        $strippedTitle = trim(strip_tags($title));
+        if ($strippedTitle == '') {
+            return 'Unnamed_'.Yii::$app->security->generateRandomString(6);
+        }
+        return $strippedTitle;
+    }
 
-	/**
-	 * Purify the HTML code only if its container type is html (conditional validation)
-	 * Using a fixed config (see https://www.kalemzen.com.tr/htmlpurifier/configdoc/plain.html for the config documentation)
-	 *
-	 * @param string $html the HTML code to be purified
-	 * @return string the purified HTML code
-	 */
+    /**
+     * Purify the HTML code only if its container type is html (conditional validation)
+     * Using a fixed config (see https://www.kalemzen.com.tr/htmlpurifier/configdoc/plain.html for the config documentation)
+     *
+     * @param string $html the HTML code to be purified
+     * @return string the purified HTML code
+     */
     public function purifyFilter($html)
     {
-	    $settings = new SettingsForm();
-	    $purifierConfig = [
-			    'HTML.Allowed' => $settings->htmlContainerPageAllowedHTML,
-			    'CSS.Proprietary' => true,
-			    'CSS.AllowedProperties' => $settings->htmlContainerPageAllowedCSSProperties,
-	    ];
-	    return HtmlPurifier::process($html, $purifierConfig);
+        $settings = new SettingsForm();
+        $purifierConfig = [
+                'HTML.Allowed' => $settings->htmlContainerPageAllowedHTML,
+                'CSS.Proprietary' => true,
+                'CSS.AllowedProperties' => $settings->htmlContainerPageAllowedCSSProperties,
+        ];
+        return HtmlPurifier::process($html, $purifierConfig);
     }
 
     /**

--- a/models/ContainerPage.php
+++ b/models/ContainerPage.php
@@ -120,10 +120,11 @@ class ContainerPage extends ContentActiveRecord implements Searchable, CustomCon
 	 */
     public function purifyFilter($html)
     {
+	    $settings = new SettingsForm();
 	    $purifierConfig = [
-			    'HTML.Allowed' => '*[style],*[class],div,p,br,b,strong,i,em,u,s,a[href|target],ul,li,ol,span,h1,h2,h3,h4,h5,h6,sub,sup,blockquote,pre,img[src|alt],hr,font[size|color]',
+			    'HTML.Allowed' => $settings->htmlContainerPageAllowedHTML,
 			    'CSS.Proprietary' => true,
-			    'CSS.AllowedProperties' => 'color,background-color,width,height,border-radius',
+			    'CSS.AllowedProperties' => $settings->htmlContainerPageAllowedCSSProperties,
 	    ];
 	    return HtmlPurifier::process($html, $purifierConfig);
     }

--- a/views/admin/settings.php
+++ b/views/admin/settings.php
@@ -45,6 +45,10 @@ use yii\helpers\Html;
                     <?= Yii::t('CustomPagesModule.base', 'Please keep in mind that php based pages are vulnerable to security issues, especially when handling user input. For more information, please have a look at <a href="{url}">Yii\'s Security best practices</a>.', ['url' => 'http://www.yiiframework.com/doc-2.0/guide-security-best-practices.html']) ?>
                 </div>
             </div>
+            <div id="htmlPurifierSettings">
+                <?= $form->field($model, 'htmlContainerPageAllowedHTML'); ?>
+                <?= $form->field($model, 'htmlContainerPageAllowedCSSProperties'); ?>
+            </div>
 
         <hr>
 


### PR DESCRIPTION
These are some changes to the module settings that can enhance the custom pages feature customization:
- Allowed HTML whitelist field
- Allowed CSS properties whitelist field

Applied some regex validation rules to this fields.